### PR TITLE
Made cuisine options lowercase

### DIFF
--- a/backend/Mealworm/src/fetchRequest/yelp.js
+++ b/backend/Mealworm/src/fetchRequest/yelp.js
@@ -13,7 +13,7 @@ function buildSearch(location, distance, cuisine) {
                  '&radius=' + (distance * 1610); // In meters
 
     if (cuisine != null) {
-        search += '&categories=' + cuisine;
+        search += '&categories=' + cuisine.toLowerCase();
     }
     return 'https://api.yelp.com/v3/businesses/search' + search;
 }


### PR DESCRIPTION
This fixes #6 - cuisines must be in lowercase to be understood by yelp