### PR TITLE
Add min and max to distance filter

### DIFF
--- a/frontend/Mealworm/src/components/searchInputFields/SearchInputFields.js
+++ b/frontend/Mealworm/src/components/searchInputFields/SearchInputFields.js
@@ -19,7 +19,14 @@ export default function SearchInputFields(props) {
                     }
                 />
             </div>
-            <div className="SIF-filters-row">
+            <div
+                className="SIF-filters-row"
+                style={
+                    validDistance ?
+                    {} :
+                    {marginBottom: "-23px"}
+                }
+            >
                 <TextField
                     label="Distance (mi)"
                     variant="filled"


### PR DESCRIPTION
Fixes #10 - prevents autofilling of invalid distance input via scrolling and enforces limits on min and max